### PR TITLE
画面遷移をする際にラグがあったがサブスレッドで録音を開始することによりラグを修正

### DIFF
--- a/TapReco.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/TapReco.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -2,7 +2,7 @@
   "object": {
     "pins": [
       {
-        "package": "Lottie",
+        "package": "lottie-ios",
         "repositoryURL": "https://github.com/airbnb/lottie-ios",
         "state": {
           "branch": null,

--- a/TapReco/View/HomeView.swift
+++ b/TapReco/View/HomeView.swift
@@ -23,8 +23,19 @@ struct HomeView: View {
             }
         }.onChange(of: isRecording) { isRecording in
             if isRecording {
-                TimerHolder().start()
-                audioRecorder.record()
+                let group = DispatchGroup()
+                let dispatchQueue = DispatchQueue(label: "queue", attributes: .concurrent)
+                group.enter()
+                
+                dispatchQueue.async(group: group) {
+                    audioRecorder.record()
+                    group.leave()
+                }
+                
+                group.notify(queue: .main) {
+                    TimerHolder().start()
+                }
+                
             } else {
                 audioRecorder.recordStop()
             }


### PR DESCRIPTION
## 概要
* AudioRecoderの録音開始時にメインスレッドをブロックしてしまい0.1秒程度遷移が遅くなってしまっていたので録音開始をサブスレッドで実行し、完了した時に録音開始のタイマーが流れるようにした